### PR TITLE
Fix: Agregar dominio publico de la app

### DIFF
--- a/eventhub/settings.py
+++ b/eventhub/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = "django-insecure--f67ll=2-b2qolla9=1f8mtg@s=l8^y8aj=@ij-0f4)eg@%8(0
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["eventhub-zdkw.onrender.com"]
 
 
 # Application definition


### PR DESCRIPTION
Agregamos el dominio público de nuestra aplicación en la variable ALLOWED_HOSTS de las configurciones del sistema 